### PR TITLE
fix no file in path error

### DIFF
--- a/src/organize_media_files.py
+++ b/src/organize_media_files.py
@@ -169,7 +169,7 @@ def organize_files(src_path, dest_path, files_extensions, filename_suffix=""):
 
     if len(os.listdir(_src_path)) <= 0:
         logger.warning("No files in path: {}".format(_src_path))
-        return 0, 0, 0
+        return 0, 0, 0, 0
     else:
         num_files_processed = 0
         num_files_removed = 0


### PR DESCRIPTION
script broke on empty folder

Traceback (most recent call last):
  File "/home/OrganizeMediaFiles/src/organize_media_files.py", line 322, in <module>
    main()
  File "/home/OrganizeMediaFiles/src/organize_media_files.py", line 291, in main
    img_processed, img_removed, img_copied, img_skipped = organize_files(IMAGES_SOURCE_PATH,
  File "/home/OrganizeMediaFiles/src/organize_media_files.py", line 186, in organize_files
    _num_files_processed, _num_files_removed, _num_files_copied, _num_files_skipped = organize_files(
  File "/home/OrganizeMediaFiles/src/organize_media_files.py", line 186, in organize_files
    _num_files_processed, _num_files_removed, _num_files_copied, _num_files_skipped = organize_files(
  File "/home/OrganizeMediaFiles/src/organize_media_files.py", line 186, in organize_files
    _num_files_processed, _num_files_removed, _num_files_copied, _num_files_skipped = organize_files(
ValueError: not enough values to unpack (expected 4, got 3)